### PR TITLE
v1 Versioning skeleton

### DIFF
--- a/e2e-test/server/serve_test.go
+++ b/e2e-test/server/serve_test.go
@@ -33,7 +33,7 @@ func TestServe(t *testing.T) {
 		}
 	}()
 
-	req, err := http.NewRequestWithContext(context, http.MethodGet, "http://localhost:9090/pipes", http.NoBody)
+	req, err := http.NewRequestWithContext(context, http.MethodGet, "http://localhost:9090/v1/pipes/", http.NoBody)
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -1,0 +1,15 @@
+package server
+
+import "github.com/gin-gonic/gin"
+
+const version = "/v1"
+
+func (s *Service) routes(engine *gin.Engine) {
+	v1 := engine.Group(version)
+
+	// Add routes for pipes
+	pipes := v1.Group("/pipes")
+	pipes.GET("/", s.getPipes)
+
+	// Add rest of routes
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -70,7 +70,7 @@ func New(opts Options, cl client.Interface, health *health.Service, l *slog.Logg
 		svr:    svr,
 	}
 
-	r.GET("/pipes", s.getPipes)
+	s.routes(r)
 
 	return s
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -23,7 +23,7 @@ func TestGetPipes(t *testing.T) {
 
 	router := server.svr.Handler
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/pipes", nil)
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/v1/pipes/", nil)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, 200, w.Code)


### PR DESCRIPTION
 Since our project is relatively small, I am attempting to manage versioning within the `pkg/server` package. An alternative approach could be to create a package `pkg/server/v1` for top-level grouping and routing, with additional packages for specific use case groups, such as `pkg/server/v1/pipes`